### PR TITLE
Updated tensorboard logdir

### DIFF
--- a/server/tensorboard.ts
+++ b/server/tensorboard.ts
@@ -26,7 +26,7 @@ export class Tensorboard {
                 )
         )
         let args = [
-            `--logdir_spec=${paths.join(',')}`,
+            `--logdir=${paths.join(',')}`,
             '--port',
             `${this.port}`
         ]


### PR DESCRIPTION
Hi, thanks for the great work. I'm integrating lab with my trainig routine.
I noticed that the usage of `--logdir_spec` [is not advised](https://github.com/tensorflow/tensorboard/blob/master/README.md#logdir--logdir_spec-legacy-mode), also it was causing an issue in my setup (tensorboard v 1.14). I solved that modifying the command to launch it.